### PR TITLE
feat: api 작성(07/20 명세서 작성 기준)

### DIFF
--- a/src/api/Auth/AuthService/index.ts
+++ b/src/api/Auth/AuthService/index.ts
@@ -1,57 +1,69 @@
 import basicClient from '../basicClient';
 
-export const login = async (login_email: string, password: string) => {
-  const response = await basicClient.post(
-    '/api/member/login',
-    {
-      login_email,
-      password,
-    },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  );
+// export const login = async (login_email: string, password: string) => {
+//   const response = await basicClient.post(
+//     '/api/member/login',
+//     {
+//       login_email,
+//       password,
+//     },
+//     {
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//     },
+//   );
 
-  if (response.data.access_token) {
-    localStorage.setItem('token', JSON.stringify(response.data));
-  }
-  return response.data;
+//   if (response.data.access_token) {
+//     localStorage.setItem('token', JSON.stringify(response.data.access_token));
+//   }
+//   return response.data;
+// };
+
+//login_email: string, password: string)
+export const login = async (body: {}) => {
+  return basicClient.post('/api/member/login', body, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 };
 
 export const logout = () => {
   localStorage.removeItem('token');
 };
 
-export const getCurrentUser = () => {
-  return JSON.parse(localStorage.getItem('token')!);
-};
-
 //db 명칭상 이유로 nickname => name
-export const register = async (
-  login_email: string,
-  name: string,
-  password: string,
-) => {
-  const response = await basicClient.post(
-    '/api/member/register',
-    {
-      login_email,
-      name,
-      password,
+// export const register = async (
+//   login_email: string,
+//   name: string,
+//   password: string,
+// ) => {
+//   const response = await basicClient.post(
+//     '/api/member/register',
+//     {
+//       login_email,
+//       name,
+//       password,
+//     },
+//     {
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//     },
+//   );
+//   return response.data;
+// };
+export const register = async (body: {}) => {
+  return basicClient.post('/api/member/register', body, {
+    headers: {
+      'Content-Type': 'application/json',
     },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  );
-  return response.data;
+  });
 };
 
 export const kakaoLoginSendToken = async (code: string) => {
-  const response = await basicClient.post(
+  return await basicClient.post(
     '/api/auth/kakao/token',
     { code },
     {
@@ -60,5 +72,4 @@ export const kakaoLoginSendToken = async (code: string) => {
       },
     },
   );
-  return response;
 };

--- a/src/api/Review/index.ts
+++ b/src/api/Review/index.ts
@@ -1,0 +1,10 @@
+// 해당부분이 User 03-a 맞나요?? 03-a 기준 재작성해놓았는데 확인부탁드립니다.
+import basicClient from '../Auth/basicClient';
+// memberId: string
+// export const fetchReviews = async (body: {}) => {
+//   return basicClient.get('api/member/${memberId}/review', body);
+// };
+
+// export const fetchReview = async (body: {}) => {
+//   return basicClient.get('/api/review/${reviewId}/detail', body);
+// };

--- a/src/api/User/index.ts
+++ b/src/api/User/index.ts
@@ -1,0 +1,27 @@
+import basicClient from '../Auth/basicClient';
+
+export const getUSer = async () => {
+  return basicClient.get('/api/member');
+};
+
+//특정 유저의 리뷰 목록 표시 request api 미작성
+
+//Body:
+// "nickname": "string",
+// "profile_image_url": "string",
+// "description": "string"
+export const changeProfile = async (body: {}) => {
+  return basicClient.put('/api/member', body);
+};
+
+//  body => "password": "string",                    O
+export const changePassword = async (body: {}) => {
+  return basicClient.put('/api/member/change-password', body);
+};
+
+//body =>
+// "login_email" : "string"
+// "password": "string",
+export const membershipWithdrawal = async (body: {}) => {
+  return basicClient.delete('/api/member', body);
+};

--- a/src/pages/Auth/Login/index.tsx
+++ b/src/pages/Auth/Login/index.tsx
@@ -34,9 +34,13 @@ const Login: FC = () => {
   const navigate = useNavigate();
   const handleSubmit = async (values: { email: string; password: string }) => {
     try {
-      const response = await login(values.email, values.password);
-      console.log(response);
-      if (response.access_token) {
+      const response = await login(values);
+      if (response.data.access_token) {
+        localStorage.setItem(
+          'token',
+          JSON.stringify(response.data.access_token),
+        );
+
         navigate('/');
         toast({
           title: '로그인 성공!',
@@ -48,7 +52,6 @@ const Login: FC = () => {
         });
       }
     } catch (err: any) {
-      console.log(err);
       if (err.response.status === 400) {
         if (err.response.data === INVALID_REUEST_BODY_SERVER_MESSAGE) {
           setError(INVALID_REUEST_BODY_MESSAGE);

--- a/src/pages/Auth/Register/index.tsx
+++ b/src/pages/Auth/Register/index.tsx
@@ -39,13 +39,7 @@ const Register: FC = () => {
     password: string;
   }) => {
     try {
-      const userData = await register(
-        values.email,
-        values.name,
-        values.password,
-      );
-      console.log(userData);
-
+      const userData = await register(values);
       if (userData) {
         toast({
           title: '회원가입 성공!',
@@ -58,7 +52,6 @@ const Register: FC = () => {
         navigate('/login');
       }
     } catch (err: any) {
-      console.log(err.response.data);
       if (err.response.status === 400) {
         setError(INVALID_REQUEST_EMAIL_OR_PASSWORD);
       }

--- a/src/pages/Auth/SocialLogin/KaKao/SocialKakaoRedirectPage/index.tsx
+++ b/src/pages/Auth/SocialLogin/KaKao/SocialKakaoRedirectPage/index.tsx
@@ -16,7 +16,7 @@ const SocialKakaoRedirectPage: FC = () => {
           const response = await kakaoLoginSendToken(code);
           console.log(response);
           if (response.status === 200) {
-            localStorage.setItem('token', response.data);
+            localStorage.setItem('token', response.data.access_token);
             toast({
               title: '로그인 성공!',
               description: `로그인에 성공하였습니다.`,


### PR DESCRIPTION
1. api 명세서 기준 request 작성 => response는 담당 페이지에서 Response 참고하여 작성
2. access_token 저장방식 변경 : 기존 {access_token : 'example_string_code'} 자체를 저장했다면 현재 'example_string_code'만 저장되도록 수정 => response 작성시 참고

3. api/Review: 재빈님이 작성한 api 부분 리팩토링하여 새로운 페이지에 작성 => 현재 주석처리 중이니 확인후 리뷰부탁드려요.

4. 계곡 api Request 작성 안되어 있어서 보류 